### PR TITLE
feat: Update relation helpers properties setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ models:
   // Expr partition type requires an expression (e.g., date_trunc) specified in partition_by
   order_by: ['some_column']             // only for PRIMARY table_type
   partition_type: 'RANGE'               // RANGE or LIST or Expr Need to be used in combination with partition_by configuration
-  properties: [{"replication_num":"1", "in_memory": "true"}]
+  properties: {"replication_num":"1", "in_memory": "true"}
   refresh_method: 'async'               // only for materialized view default manual
   
   // For 'materialized=incremental' in version >= 3.4

--- a/dbt/include/starrocks/macros/adapters/relation_helpers.sql
+++ b/dbt/include/starrocks/macros/adapters/relation_helpers.sql
@@ -37,8 +37,6 @@
 
   {%- if properties is none -%}
         {%- set properties = config.get('properties', {"replication_num":"1"}) -%}
-  {%- else -%}
-        {%- set properties = fromjson(config.get('properties')) -%}
   {%- endif -%}
 
   {# 1. SET ENGINE #}

--- a/tests/functional/adapter/test_basic.py
+++ b/tests/functional/adapter/test_basic.py
@@ -10,10 +10,48 @@ from dbt.tests.adapter.basic.test_generic_tests import BaseGenericTests
 from dbt.tests.adapter.basic.test_snapshot_check_cols import BaseSnapshotCheckCols
 from dbt.tests.adapter.basic.test_snapshot_timestamp import BaseSnapshotTimestamp
 from dbt.tests.adapter.basic.test_adapter_methods import BaseAdapterMethod
+from dbt.tests.util import (
+    check_relation_types,
+    check_relations_equal,
+    check_result_nodes_by_name,
+    relation_from_name,
+    run_dbt,
+)
+
+base_table_model_with_props_sql = """
+{{ 
+    config(
+        materialized = 'table', 
+        engine='OLAP', 
+        distributed_by=['id'], 
+        buckets="2 ",
+        properties={"replication_num":"1", 'colocate_with': 'cg1'}
+    ) 
+}}
+select * from {{ ref('base') }}
+""".lstrip()
+
+create_table_with_props_sql = """
+CREATE TABLE `table_model_with_props` (
+  `id` int(11) NULL COMMENT "",
+  `name` varchar(65533) NULL COMMENT "",
+  `some_date` datetime NULL COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`id`, `name`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 2 
+PROPERTIES (
+"colocate_with" = "cg1",
+"compression" = "LZ4",
+"fast_schema_evolution" = "true",
+"replicated_storage" = "true",
+"replication_num" = "1"
+);
+""".replace("\n", "").replace(" ", "")
+
 
 # StarRocks doesn't support materialization from table to view https://github.com/StarRocks/dbt-starrocks/issues/33
 class TestSimpleMaterializationsMyAdapter(BaseSimpleMaterializations):
-    @pytest.fixture(scope="class")
+
     def test_base(self, project):
 
         # seed command
@@ -69,7 +107,27 @@ class TestSimpleMaterializationsMyAdapter(BaseSimpleMaterializations):
         }
         check_relation_types(project.adapter, expected)
 
-    pass
+class TestSimpleMaterializationWithProperties(BaseSimpleMaterializations):
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "table_model_with_props.sql": base_table_model_with_props_sql,
+        }
+
+    def test_base(self, project):
+        results = run_dbt(["seed"])
+        # seed result length
+        assert len(results) == 1
+
+        # run command
+        results = run_dbt(["run"])
+        # run result length
+        assert len(results) == 1
+
+        relation = results[0].node.relation_name
+        result = project.run_sql(f"SHOW CREATE TABLE {relation}", fetch="one")[1]
+        assert result.replace(' ', '').replace('\n', '') == create_table_with_props_sql
 
 
 class TestSingularTestsMyAdapter(BaseSingularTests):


### PR DESCRIPTION
# Context

Currently, the `README.md` documentation contains 2 different ways of setting `properties`:
- `properties: [{"replication_num":"1", "in_memory": "true"}]`
- `properties={"storage_medium":"SSD"}` 

For `OLAP` tables, this will yield the following error: 

```
  the JSON object must be str, bytes or bytearray, not dict
  
  > in macro starrocks__create_table_as (macros/materializations/models/table.sql)
  > called by macro create_table_as (macros/relations/table/create.sql)
  > called by macro default__get_create_table_as_sql (macros/relations/table/create.sql)
  > called by macro get_create_table_as_sql (macros/relations/table/create.sql)
  > called by macro statement (macros/etc/statement.sql)
  > called by macro materialization_table_default (macros/materializations/models/table.sql)
  > called by model table_model_with_props (models/table_model_with_props.sql)
```

The root cause of this error is the usage of `fromjson` which expects a  string to deserialize ([Ref](https://docs.getdbt.com/reference/dbt-jinja-functions/fromjson)). Which is not the type of object being returned by the following code in `relation_helpers.sql`: 

```
{%- set properties = config.get('properties') -%}
```

**Attempting a workaround**

A workaround could be to set the the `properties` value as a JSON string, to silence the `fromjson` error. 

However, the `properties` handling code (The `{# 6. SET PROPERTIES #}` section in the helpers' file) expect an object on which it can call `items`. 

This causes the table to be created without the `properties`: 

```
  create table `test17407721677099540749_test_basic`.`table_model_with_props__dbt_tmp`
    DISTRIBUTED BY HASH (id)BUCKETS 2 as 
select * from `test17407721677099540749_test_basic`.`base`
```

# Solution

- Document the `properties` type as only dictionary in the `README.md` 
- Remove the `else` condition calling the `fromjson` 
- Add a test case to make sure the table is created with the expected `properties` 